### PR TITLE
Ntaw 595

### DIFF
--- a/app/ms1/task_functions.py
+++ b/app/ms1/task_functions.py
@@ -260,7 +260,7 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
 
 
 def collapse_adduct_id_array(the_array, delta_name):
-    non_zero = the_array[the_array > 0]
+    non_zero = the_array[the_array > 0].astype(str)
     if len(non_zero) == 0:
         return ""
     adduct_info_str = "({});".format(delta_name).join(non_zero) + "({});".format(delta_name)

--- a/app/ms1/task_functions.py
+++ b/app/ms1/task_functions.py
@@ -99,9 +99,7 @@ def flags(df):
     SCORE = 90  # formula match is 90
     df["Neg_Mass_Defect"] = np.where((df.Mass - df.Mass.round(0)) < 0, "1", "0")
     df["Halogen"] = np.where(df.Compound.str.contains("F|l|r|I"), "1", "0")
-    df["Formula_Match"] = np.where(
-        df.Score != df.Score, "0", "1"
-    )  # check if it does not have a score
+    df["Formula_Match"] = np.where(df.Score != df.Score, "0", "1")  # check if it does not have a score
     df["Formula_Match_Above90"] = np.where(df.Score >= SCORE, "1", "0")
     df["X_NegMassDef_Below90"] = np.where(
         ((df.Score < SCORE) & (df.Neg_Mass_Defect == "1") & (df.Halogen == "1")),
@@ -150,10 +148,7 @@ def passthrucol(df_in):
         if len(sublist) == 1 and not any(x in sublist for x in active_cols)
     ]
     headers = ["Feature ID"] + [
-        item
-        for sublist in all_headers
-        for item in sublist
-        if not any(x in item for x in pt_headers)
+        item for sublist in all_headers for item in sublist if not any(x in item for x in pt_headers)
     ]
     # Save pass through columns in df
     df_pt = df[pt_headers]
@@ -219,9 +214,7 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
         # Matrix multiplication, keep highest # row if multiple adducts
         has_adduct_number = has_adduct_matrix * is_id_matrix
         # if is adduct of multiple, keep highest # row
-        has_adduct_number_flat = np.max(
-            has_adduct_number, axis=1
-        )  # these will all be the same down columns
+        has_adduct_number_flat = np.max(has_adduct_number, axis=1)  # these will all be the same down columns
         unique_adduct_number = np.where(
             has_adduct_number_flat != 0, has_adduct_number_flat, is_adduct_number_flat
         ).astype(int)
@@ -293,9 +286,7 @@ def chunk_adducts(df_in, n, step, a_name, delta, Mass_Difference, Retention_Diff
     return output
 
 
-def adduct_identifier(
-    df_in, adduct_selections, Mass_Difference, Retention_Difference, ppm, ionization
-):
+def adduct_identifier(df_in, adduct_selections, Mass_Difference, Retention_Difference, ppm, ionization):
     """
     Function that does the front-end of the old 'adduct_identifier'; we trim the input data by identifying
     features that are near to adduct distance from another feature. This shortened dataframe is used to
@@ -327,21 +318,21 @@ def adduct_identifier(
     ]
     # no change to neutral losses
     neutral_losses_li = [
-        ("H2O", 18.010565),
-        ("2H2O", 36.02113),
-        ("3H2O", 54.031695),
-        ("4H2O", 72.04226),
-        ("5H2O", 90.052825),
-        ("NH3", 17.0265),
-        ("O", 15.99490),
-        ("CO", 29.00220),
-        ("CO2", 43.989829),
-        ("C2H4", 28.03130),
-        ("HFA", 46.00550),
-        ("HAc", 60.02110),
-        ("MeOH", 32.02620),
-        ("ACN", 41.02650),
-        ("IsoProp", 60.05810),
+        ("H2O", -18.010565),
+        ("2H2O", -36.02113),
+        ("3H2O", -54.031695),
+        ("4H2O", -72.04226),
+        ("5H2O", -90.052825),
+        ("NH3", -17.0265),
+        ("O", -15.99490),
+        ("CO", -29.00220),
+        ("CO2", -43.989829),
+        ("C2H4", -28.03130),
+        ("HFA", -46.00550),
+        ("HAc", -60.02110),
+        ("MeOH", -32.02620),
+        ("ACN", -41.02650),
+        ("IsoProp", -60.05810),
     ]
     # Determine possible adduct dictionary according to ionization
     if ionization == "positive":
@@ -371,9 +362,7 @@ def adduct_identifier(
             list_of_mass_shifts_RT_pairs.append(list(zip(df["Rounded RT"], df[col1])))
             list_of_mass_shifts_RT_pairs.append(list(zip(df["Rounded RT"], df[col2])))
         # Extend list
-        list_of_mass_shifts_RT_pairs = [
-            item for sublist in list_of_mass_shifts_RT_pairs for item in sublist
-        ]
+        list_of_mass_shifts_RT_pairs = [item for sublist in list_of_mass_shifts_RT_pairs for item in sublist]
         # Remove duplicate tuples (sets don't carry duplicates)
         list_of_mass_shifts_RT_pairs = list(set(list_of_mass_shifts_RT_pairs))
         # Filter df for features to check for adducts
@@ -388,17 +377,13 @@ def adduct_identifier(
         # If 'to_test' is less than n, send it straight to 'adduct_matrix'
         if to_test.shape[0] <= n:
             for a_name, delta in possible_adduct_deltas.items():
-                to_test = adduct_matrix(
-                    to_test, a_name, delta, Mass_Difference, Retention_Difference, ppm
-                )
+                to_test = adduct_matrix(to_test, a_name, delta, Mass_Difference, Retention_Difference, ppm)
         # Else, calculate the moving window size and send 'to_test' to 'chunk_adducts'
         else:
             step = n - window_size(to_test)
             # Loop through possible adducts, perform 'adduct_matrix'
             for a_name, delta in possible_adduct_deltas.items():
-                to_test = chunk_adducts(
-                    to_test, n, step, a_name, delta, Mass_Difference, Retention_Difference, ppm
-                )
+                to_test = chunk_adducts(to_test, n, step, a_name, delta, Mass_Difference, Retention_Difference, ppm)
         # Concatenate 'Has Adduct or Loss?', 'Is Adduct or Loss?', 'Adduct or Loss Info' to df
         df_in = pd.merge(
             df_in,
@@ -445,9 +430,7 @@ def chunk_dup_remove(df_in, n, step, mass_cutoff, rt_cutoff, ppm):
         dupe_li.append(dupes)
     # Concatenate results, drop duplicates from overlap
     output = pd.concat(li, axis=0).drop_duplicates(subset=["Mass", "Retention_Time"], keep="first")
-    dupe_df = pd.concat(dupe_li, axis=0).drop_duplicates(
-        subset=["Mass", "Retention_Time"], keep="first"
-    )
+    dupe_df = pd.concat(dupe_li, axis=0).drop_duplicates(subset=["Mass", "Retention_Time"], keep="first")
     # Return de-duplicated dataframe (output) and removed duplicates (dupe_df)
     return output, dupe_df
 
@@ -469,8 +452,7 @@ def dup_matrix_remove(df_in, mass_cutoff, rt_cutoff, ppm):
     # Find indices where differences are less than 'mass_cutoff' and 'rt_cutoff'
     if ppm:
         duplicates_matrix = np.where(
-            (abs(diff_matrix_mass / masses_matrix) * 10**6 <= mass_cutoff)
-            & (abs(diff_matrix_rt) <= rt_cutoff),
+            (abs(diff_matrix_mass / masses_matrix) * 10**6 <= mass_cutoff) & (abs(diff_matrix_rt) <= rt_cutoff),
             1,
             0,
         )
@@ -534,8 +516,7 @@ def dup_matrix_flag(df_in, mass_cutoff, rt_cutoff, ppm):
     # Find indices where differences are less than 'mass_cutoff' and 'rt_cutoff'
     if ppm:
         duplicates_matrix = np.where(
-            (abs(diff_matrix_mass / masses_matrix) * 10**6 <= mass_cutoff)
-            & (abs(diff_matrix_rt) <= rt_cutoff),
+            (abs(diff_matrix_mass / masses_matrix) * 10**6 <= mass_cutoff) & (abs(diff_matrix_rt) <= rt_cutoff),
             1,
             0,
         )
@@ -632,24 +613,15 @@ def statistics(df_in):
         axis=1,
     )
     medians = pd.concat(
-        [
-            df[x].median(axis=1, skipna=True).round(4).rename(col)
-            for x, col in zip(sam_headers, med_cols)
-        ],
+        [df[x].median(axis=1, skipna=True).round(4).rename(col) for x, col in zip(sam_headers, med_cols)],
         axis=1,
     )
     stds = pd.concat(
-        [
-            df[x].std(axis=1, skipna=True).round(4).rename(col)
-            for x, col in zip(sam_headers, std_cols)
-        ],
+        [df[x].std(axis=1, skipna=True).round(4).rename(col) for x, col in zip(sam_headers, std_cols)],
         axis=1,
     )
     cvs = pd.concat(
-        [
-            (stds[scol] / means[mcol]).round(4).rename(col)
-            for mcol, scol, col in zip(mean_cols, std_cols, cv_cols)
-        ],
+        [(stds[scol] / means[mcol]).round(4).rename(col) for mcol, scol, col in zip(mean_cols, std_cols, cv_cols)],
         axis=1,
     )
     nabuns = pd.concat(
@@ -733,10 +705,7 @@ def column_sort_DFS(df_in, passthru):
     all_cols = df.columns.tolist()
     non_samples = ["MRL"]
     group_cols = [
-        sublist[0][:-1]
-        for sublist in all_headers
-        if len(sublist) > 1
-        if not any(x in sublist[0] for x in non_samples)
+        sublist[0][:-1] for sublist in all_headers if len(sublist) > 1 if not any(x in sublist[0] for x in non_samples)
     ]
     # Create list of prefixes to remove non-samples
     prefixes = [
@@ -912,8 +881,7 @@ def check_feature_tracers(df, tracers_file, Mass_Difference, Retention_Differenc
     if ppm:
         dft["Matches"] = np.where(
             (
-                abs((dft["Monoisotopic_Mass"] - dft["Observed Mass"]) / dft["Monoisotopic_Mass"])
-                * 1000000
+                abs((dft["Monoisotopic_Mass"] - dft["Observed Mass"]) / dft["Monoisotopic_Mass"]) * 1000000
                 <= Mass_Difference
             )
             & (abs(dft["Retention_Time"] - dft["Observed Retention Time"]) <= Retention_Difference),
@@ -930,9 +898,7 @@ def check_feature_tracers(df, tracers_file, Mass_Difference, Retention_Differenc
     dft = dft[dft["Matches"] == 1]
     # Caculate Occurrence Count and % in tracers
     dft["Total Detection Count"] = dft[samples].count(axis=1)
-    dft["Total Detection Percentage"] = ((dft["Total Detection Count"] / len(samples)) * 100).round(
-        2
-    )
+    dft["Total Detection Percentage"] = ((dft["Total Detection Count"] / len(samples)) * 100).round(2)
     # Get 'Matches' info into main df
     dum = dft[["Observed Mass", "Observed Retention Time", "Matches"]].copy()
     # logger.info("cft dum columns= {}".format(dum.columns.values))
@@ -1037,9 +1003,7 @@ def MRL_calc(df, docs, df_flagged, controls, Mean_Samples, Mean_MB, Std_MB):
     return df, docs, df_flagged, MRL_sample_mask
 
 
-def calculate_detection_counts(
-    df, docs, df_flagged, MRL_sample_mask, Std_MB, Mean_MB, Mean_Samples
-):
+def calculate_detection_counts(df, docs, df_flagged, MRL_sample_mask, Std_MB, Mean_MB, Mean_Samples):
     """
     Function that takes df, docs, controls, and the MRL_sample_mask and calculates
     detection counts in df and df_flagged. -- TMF 04/19/24
@@ -1050,18 +1014,12 @@ def calculate_detection_counts(
     # Determine total number of samples
     mean_samples = len(Mean_Samples)
     # Calculate percentage of samples that have a value and store in new column 'Detection_Count(non-blank_samples)(%)'
-    df["Detection_Count(non-blank_samples)(%)"] = (
-        df["Detection_Count(non-blank_samples)"] / mean_samples
-    ) * 100
-    df["Detection_Count(non-blank_samples)(%)"] = df["Detection_Count(non-blank_samples)(%)"].round(
-        1
-    )
+    df["Detection_Count(non-blank_samples)(%)"] = (df["Detection_Count(non-blank_samples)"] / mean_samples) * 100
+    df["Detection_Count(non-blank_samples)(%)"] = df["Detection_Count(non-blank_samples)(%)"].round(1)
     df_flagged["Detection_Count(non-blank_samples)(%)"] = (
         df_flagged["Detection_Count(non-blank_samples)"] / mean_samples
     ) * 100
-    df_flagged["Detection_Count(non-blank_samples)(%)"] = df_flagged[
-        "Detection_Count(non-blank_samples)(%)"
-    ].round(1)
+    df_flagged["Detection_Count(non-blank_samples)(%)"] = df_flagged["Detection_Count(non-blank_samples)(%)"].round(1)
     # Assign to docs
     docs["Detection_Count(non-blank_samples)"] = df["Detection_Count(non-blank_samples)"]
     docs["Detection_Count(non-blank_samples)(%)"] = df["Detection_Count(non-blank_samples)(%)"]
@@ -1076,9 +1034,7 @@ def MRL_flag(docs, Mean_Samples, MRL_sample_mask, missing):
     # Update empty cell masks from the docs and df dataframes
     cell_empty = docs[Mean_Samples].isnull()
     # append MRL flag (occurrence < MRL) to documentation dataframe
-    docs[Mean_Samples] = np.where(
-        ~MRL_sample_mask & cell_empty & ~missing, "MRL", docs[Mean_Samples]
-    )
+    docs[Mean_Samples] = np.where(~MRL_sample_mask & cell_empty & ~missing, "MRL", docs[Mean_Samples])
     docs[Mean_Samples] = np.where(
         ~MRL_sample_mask & ~cell_empty & ~missing,
         docs[Mean_Samples] + ", MRL",
@@ -1119,9 +1075,7 @@ def feat_removal_flag(docs, Mean_Samples, missing):
     docs["Final Occurrence Count"] = num_mask.sum(axis=1)
     # Count number of missing samples from missing mask
     docs["# of missing occurrences"] = missing.sum(axis=1)
-    docs["Unfiltered Occurrence Count"] = (
-        docs["Possible Occurrence Count"] - docs["# of missing occurrences"]
-    )
+    docs["Unfiltered Occurrence Count"] = docs["Possible Occurrence Count"] - docs["# of missing occurrences"]
     # Generate mask of str values in docs (i.e., occurrences with ANY flags are True)
     str_mask = pd.concat([docs[mean].str.contains("R|CV|MRL") for mean in Mean_Samples], axis=1)
     docs["Unfiltered Occurrence Removed Count"] = str_mask.sum(axis=1)
@@ -1129,8 +1083,7 @@ def feat_removal_flag(docs, Mean_Samples, missing):
     str_mask = pd.concat([docs[mean].str.contains("R|MRL") for mean in Mean_Samples], axis=1)
     docs["Unfiltered Occurrence Removed Count (with flags)"] = str_mask.sum(axis=1)
     docs["Final Occurrence Count (with flags)"] = (
-        docs["Unfiltered Occurrence Count"]
-        - docs["Unfiltered Occurrence Removed Count (with flags)"]
+        docs["Unfiltered Occurrence Count"] - docs["Unfiltered Occurrence Removed Count (with flags)"]
     )
 
     # Count # of times an occurrence flag contains R, CV, or MRL, and count # of just CV flags
@@ -1145,9 +1098,7 @@ def feat_removal_flag(docs, Mean_Samples, missing):
     docs["# contains MRL flag"] = contains_MRL.sum(axis=1)
     # Determine if any samples are dropped for a feature
     docs["Any Occurrences Removed?"] = np.where(
-        (docs["# contains R flag"] > 0)
-        | (docs["# contains CV flag"] > 0)
-        | (docs["# contains MRL flag"] > 0),
+        (docs["# contains R flag"] > 0) | (docs["# contains CV flag"] > 0) | (docs["# contains MRL flag"] > 0),
         1,
         0,
     )
@@ -1196,23 +1147,17 @@ def occ_drop_df(df, docs, df_flagged, Mean_Samples):
     df["Any Occurrences Removed?"] = docs["Any Occurrences Removed?"]
     df_flagged["Any Occurrences Removed?"] = docs["Any Occurrences Removed?"]
     # Create mask of occurrences dropped for replicate flag
-    rep_fails = pd.concat([docs[mean].str.contains("R") for mean in Mean_Samples], axis=1).fillna(
-        False
-    )
+    rep_fails = pd.concat([docs[mean].str.contains("R") for mean in Mean_Samples], axis=1).fillna(False)
     # Mask df and df_flagged
     df[Mean_Samples] = df[Mean_Samples].mask(rep_fails)
     df_flagged[Mean_Samples] = df_flagged[Mean_Samples].mask(rep_fails)
     # Create mask of occurrences dropped for replicate flag
-    non_detects = pd.concat(
-        [docs[mean].str.contains("MRL") for mean in Mean_Samples], axis=1
-    ).fillna(False)
+    non_detects = pd.concat([docs[mean].str.contains("MRL") for mean in Mean_Samples], axis=1).fillna(False)
     # Mask df and df_flagged
     df[Mean_Samples] = df[Mean_Samples].mask(non_detects)
     df_flagged[Mean_Samples] = df_flagged[Mean_Samples].mask(non_detects)
     # Create mask of occurrences dropped for replicate flag
-    cv_fails = pd.concat([docs[mean].str.contains("CV") for mean in Mean_Samples], axis=1).fillna(
-        False
-    )
+    cv_fails = pd.concat([docs[mean].str.contains("CV") for mean in Mean_Samples], axis=1).fillna(False)
     # Mask df
     df[Mean_Samples] = df[Mean_Samples].mask(cv_fails)
     # Add columns from docs to df / df_flagged
@@ -1227,10 +1172,7 @@ def occ_drop_df(df, docs, df_flagged, Mean_Samples):
         (df["Final Occurrence Count"] / df["Possible Occurrence Count"]).astype(float).round(2)
     )
     df_flagged["Final Occurrence Percentage (with flags)"] = (
-        (
-            df_flagged["Final Occurrence Count (with flags)"]
-            / df_flagged["Possible Occurrence Count"]
-        )
+        (df_flagged["Final Occurrence Count (with flags)"] / df_flagged["Possible Occurrence Count"])
         .astype(float)
         .round(2)
     )
@@ -1255,9 +1197,7 @@ def feat_drop_df(df, docs, df_flagged):
     df_flagged["Feature Removed?"] = docs["Feature Removed?"]
     # Subset df and df_flagged
     df = df.loc[df["Feature Removed?"] == "", :]
-    df_flagged = df_flagged.loc[
-        (df_flagged["Feature Removed?"] == "") | (docs["# is CV flag"] > 0), :
-    ]
+    df_flagged = df_flagged.loc[(df_flagged["Feature Removed?"] == "") | (docs["# is CV flag"] > 0), :]
     # Drop 'Feature Removed?' from df
     df.drop(columns=["Feature Removed?"], inplace=True)
     df_flagged.drop(columns=["Feature Removed?"], inplace=True)
@@ -1318,9 +1258,7 @@ def clean_features(df_in, controls, tracer_df=False):
     docs = cv_flag(df, docs, controls, Mean_Samples, CV_Samples, missing)
     """MRL CALCULATION/MRL MASK GENERATION"""
     # Calculate feature MRL
-    df, docs, df_flagged, MRL_sample_mask = MRL_calc(
-        df, docs, df_flagged, controls, Mean_Samples, Mean_MB, Std_MB
-    )
+    df, docs, df_flagged, MRL_sample_mask = MRL_calc(df, docs, df_flagged, controls, Mean_Samples, Mean_MB, Std_MB)
     """CALCULATE DETECTION COUNTS"""
     # Calculate Detection_Count
     df, docs, df_flagged = calculate_detection_counts(

--- a/app/ms1/task_functions.py
+++ b/app/ms1/task_functions.py
@@ -175,12 +175,12 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
     rts = df["Retention_Time"].to_numpy()
     ids = df["Feature ID"].to_numpy()
     # Reshape 'masses', 'rts', and 'ids'
-    masses_matrix = np.reshape(mass, (len(mass), 1))
-    rts_matrix = np.reshape(rts, (len(rts), 1))
-    ids_matrix = np.reshape(ids, (1, len(ids)))
+    masses_vector = np.reshape(mass, (len(mass), 1))
+    rts_vector = np.reshape(rts, (len(rts), 1))
+    ids_vector = np.reshape(ids, (1, len(ids)))
     # Create difference matrices
-    diff_matrix_mass = masses_matrix - masses_matrix.transpose()
-    diff_matrix_rt = rts_matrix - rts_matrix.transpose()
+    diff_matrix_mass = masses_vector - masses_vector.transpose()
+    diff_matrix_rt = rts_vector - rts_vector.transpose()
     # Create array of 0s
     unique_adduct_number = np.zeros(len(df.index))
     # Add 'diff_mass_matrix' by 'delta' (adduct mass)
@@ -188,8 +188,8 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
     has_adduct_diff = abs(diff_matrix_mass + delta)
     # Adjust matrix if units are 'ppm'
     if ppm:
-        has_adduct_diff = (has_adduct_diff / masses_matrix) * 10**6
-        is_adduct_diff = (is_adduct_diff / masses_matrix) * 10**6
+        has_adduct_diff = (has_adduct_diff / masses_vector) * 10**6
+        is_adduct_diff = (is_adduct_diff / masses_vector) * 10**6
     # Replace cells in 'has_adduct_diff' below 'Mass_Difference' and 'Retention_Difference' with 1, else 0
     is_adduct_matrix = np.where(
         (is_adduct_diff < Mass_Difference) & (abs(diff_matrix_rt) < Retention_Difference),
@@ -211,15 +211,15 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
     else:
         # Define 'is_id_matrix' where each row is a list of every feature ID
         row_num = len(mass)
-        is_id_matrix = np.tile(ids_matrix, (row_num, 1))
+        id_matrix = np.tile(ids_vector, (row_num, 1))
         # Matrix multiplication, set all feature IDs to 0 except adduct/loss hits
-        is_adduct_number = is_adduct_matrix * is_id_matrix
+        is_adduct_number = is_adduct_matrix * id_matrix
         # For each feature (column), make a string listing all 'is adduct' numbers for the info column
         is_adduct_number_flat = np.apply_along_axis(
             collapse_adduct_id_array, 1, is_adduct_number, a_name
         )
         # Matrix multiplication, set all feature IDs to 0 except adduct/loss hits
-        has_adduct_number = has_adduct_matrix * is_id_matrix
+        has_adduct_number = has_adduct_matrix * id_matrix
         # For each feature (column), make a string listing all 'has adduct' numbers for the info column
         has_adduct_number_flat = np.apply_along_axis(
             collapse_adduct_id_array, 1, has_adduct_number, a_name
@@ -355,11 +355,11 @@ def adduct_identifier(
         ("CO", -29.00220),
         ("CO2", -43.989829),
         ("C2H4", -28.03130),
-        ("HFA", -46.00550),
-        ("HAc", -60.02110),
-        ("MeOH", -32.02620),
-        ("ACN", -41.02650),
-        ("IsoProp", -60.05810),
+        ("HFA", 46.00550),  # note here and below - not losses? but still neutral?
+        ("HAc", 60.02110),
+        ("MeOH", 32.02620),
+        ("ACN", 41.02650),
+        ("IsoProp", 60.05810),
     ]
     # Determine possible adduct dictionary according to ionization
     if ionization == "positive":

--- a/app/ms1/task_functions.py
+++ b/app/ms1/task_functions.py
@@ -218,7 +218,7 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
         # is_adduct_number_flat = np.max(is_adduct_number, axis=1)
         # For each feature (column), make a string listing all 'is adduct' numbers for the info column
         is_adduct_number_flat = np.apply_along_axis(
-            collapse_adduct_id_array, 0, is_adduct_number, a_name
+            collapse_adduct_id_array, 1, is_adduct_number, a_name
         )
         # Matrix multiplication, keep highest # row if multiple adducts
         has_adduct_number = has_adduct_matrix * is_id_matrix
@@ -226,7 +226,7 @@ def adduct_matrix(df, a_name, delta, Mass_Difference, Retention_Difference, ppm)
         # has_adduct_number_flat = np.max(has_adduct_number, axis=1)  # these will all be the same down columns
         # For each feature (column), make a string listing all 'has adduct' numbers for the info column
         has_adduct_number_flat = np.apply_along_axis(
-            collapse_adduct_id_array, 0, has_adduct_number, a_name
+            collapse_adduct_id_array, 1, has_adduct_number, a_name
         )
         # unique_adduct_number = np.where(
         #    has_adduct_number_flat != 0, has_adduct_number_flat, is_adduct_number_flat


### PR DESCRIPTION
## NTAW-595 - Fixing direction of neutral loss adducts and general adduct ID improvements

## Summary of changes:
* Neutral loss relationships are no longer reversed (has vs is adduct/loss)
* Delta values were changed to negative for losses in the adduct/loss dictionary
* Features can be marked as both 'has adduct' and 'is adduct' 
* More possible adduct/loss relationships are detected 
* Features can be marked as both 'has adduct' and 'is adduct' 
* The 'has adduct or loss?' column is no longer a 'count' of how many it has, it's just 1/0 as in TRUE/FALSE, which is more true to the name of the column. If we ever wanted to add a count, we should do it in a new column
* Some variable names in the adduct matrix function were renamed for clarity (no impact on function).

## How to test:
* Directly comparable results are attached on Jira pre and post ticket (Final Occurrence Matrix tabs): https://jira.epa.gov/browse/NTAW-595

## Test Results:
The number of features identified as adducts for the test files increases from 407 (7.7%) to 463 (8.7%).
